### PR TITLE
fix: outer source completes too early

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "callbag-for-each": "^1.0.1",
+    "callbag-from-iter": "^1.3.0",
+    "callbag-interval": "^1.2.0",
     "callbag-map": "^1.0.1",
     "callbag-pipe": "^1.1.1",
     "callbag-subject": "^1.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,16 @@ export default function concatMap(project) {
     const innerSink = (type, data) => {
       if (type === 0) {
         innerTalkback = data
-        innerTalkback(1)
         return
       }
 
       if (type === 1) {
         sink(1, data)
-        innerTalkback(1)
+        return
+      }
+
+      if (type === 2 && data) {
+        sink(2, data)
         return
       }
 
@@ -23,6 +26,7 @@ export default function concatMap(project) {
         innerTalkback = null
 
         if (queue.length === 0) {
+          sink(2)
           return
         }
 
@@ -52,14 +56,6 @@ export default function concatMap(project) {
 
         project(data)(0, innerSink)
         return
-      }
-
-      if (type === 2) {
-        sink(2, data)
-
-        if (innerTalkback !== null) {
-          innerTalkback(2, data)
-        }
       }
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,18 @@ export default function concatMap(project) {
     const queue = []
     let innerTalkback = null
     let sourceTalkback
+    let outerSrcFinished = false
 
     const innerSink = (type, data) => {
       if (type === 0) {
         innerTalkback = data
+        innerTalkback(1)
         return
       }
 
       if (type === 1) {
         sink(1, data)
+        innerTalkback(1)
         return
       }
 
@@ -25,7 +28,7 @@ export default function concatMap(project) {
       if (type === 2) {
         innerTalkback = null
 
-        if (queue.length === 0) {
+        if (queue.length === 0 && outerSrcFinished) {
           sink(2)
           return
         }
@@ -56,6 +59,10 @@ export default function concatMap(project) {
 
         project(data)(0, innerSink)
         return
+      }
+
+      if (type === 2) {
+        outerSrcFinished = true
       }
     })
   }


### PR DESCRIPTION
Ignore the `complete` message from the source, so that we can get all data from the inner sources.